### PR TITLE
Use concrete modules so that you can at least terraform validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ This repository contains an example of how to use [Jsonnet](https://jsonnet.org/
 This represents a toy example of an AWS stack containing a VPC and MySQL database, that uses a fictional Terraform
 module to deploy each.
 
-**This is not a fully executable example**.
+> **NOTE**
+>
+> The underlying module calls use `null_resource`s to simulate the resources. However, the general pattern should be
+> extensible to real world modules and use cases.
 
 Refer to [Comparison to Terraform HCL](https://docs.tflibsonnet.com/docs/what-is-tf-libsonnet/#comparison-to-terraform-hcl)
 for the motivating example and a full walkthrough.

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  description = "Name of the MySQL database."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC to deploy the MySQL Database into."
+  type        = string
+}
+
+resource "null_resource" "mysql" {
+  triggers = {
+    name   = var.name
+    vpc_id = var.vpc_id
+  }
+}
+
+output "fqdn" {
+  value = null_resource.mysql.id
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  description = "Name of the VPC."
+  type        = string
+}
+
+variable "cidr_block" {
+  description = "The IPv4 CIDR block to allocate for the VPC network."
+  type        = string
+}
+
+resource "null_resource" "vpc" {
+  triggers = {
+    name       = var.name
+    cidr_block = var.cidr_block
+  }
+}
+
+output "vpc_id" {
+  value = null_resource.vpc.id
+}

--- a/stack/mysql.libsonnet
+++ b/stack/mysql.libsonnet
@@ -14,7 +14,9 @@ local aws = import 'github.com/tf-libsonnet/hashicorp-aws/main.libsonnet';
       )
       + tf.withModule(
         'mysql',
-        'github.com/myorg/my-mysql?ref=v1.0.8',
+        // NOTE: For simplicity, we self reference the current repository but in production, you should move the modules
+        // to a different repo, and use a concrete ref tag.
+        'github.com/tf-libsonnet/infrastructure-live-example//modules/mysql?ref=main',
         {
           name: envName,
           vpc_id: o._ref.data.aws_vpc.vpc.get('id'),

--- a/stack/vpc.libsonnet
+++ b/stack/vpc.libsonnet
@@ -7,7 +7,9 @@ local tf = import 'github.com/tf-libsonnet/core/main.libsonnet';
     local o =
       tf.withModule(
         'vpc',
-        'github.com/myorg/my-vpc?ref=v1.0.8',
+        // NOTE: For simplicity, we self reference the current repository but in production, you should move the modules
+        // to a different repo, and use a concrete ref tag.
+        'github.com/tf-libsonnet/infrastructure-live-example//modules/vpc?ref=main',
         {
           name: envName,
           cidr_block: cidrBlock,


### PR DESCRIPTION
This updates the example to use a concrete module (although still simulated code) so that you can at least run `terraform validate` while still keeping the example super simple. In some circumstances you may be able to run `apply`, although the setup is too much to be worth adding instructions.